### PR TITLE
Use config object instead of parsing directly

### DIFF
--- a/app/configparser.py
+++ b/app/configparser.py
@@ -1,4 +1,5 @@
 import configparser
+from dataclasses import dataclass
 from pathlib import Path
 
 CONFIG_FILE = Path("config.ini")
@@ -7,14 +8,66 @@ CONFIG_FILE = Path("config.ini")
 # initialized and using logging here would initialize with the wrong values.
 
 
+@dataclass
+class ParsedConfig:
+    # Common
+    database_file: str = "loot.db"
+    feed_file_prefix: str = "lootscraper"
+    log_file: str = "lootscraper.log"
+    log_level: str = "INFO"
+    wait_between_runs: int = 0
+
+    # Expert
+    force_update: bool = False
+
+    # Sources: Offers
+    offers_amazon: bool = True
+    offers_epic: bool = True
+    offers_steam: bool = True
+    offers_gog: bool = True
+
+    # Sources: Info
+    info_steam: bool = True
+    info_igdb: bool = True
+
+    # Actions
+    scrape_games: bool = True
+    scrape_loot: bool = True
+    scrape_info: bool = True
+    generate_feed: bool = True
+    upload_feed: bool = False
+
+    # Telegram
+    telegram_access_token: str = ""
+    telegram_developer_chat_id: int = 0
+
+    # IGDB
+    igdb_client_id: str = ""
+    igdb_client_secret: str = ""
+
+    # FTP
+    ftp_host: str = ""
+    ftp_username: str = ""
+    ftp_password: str = ""
+
+    # Feed
+    feed_author_name: str = "Eiko Wagenknecht"
+    feed_author_mail: str = "feed@ew-mail.de"
+    feed_author_web: str = "https://eiko-wagenknecht.de"
+    feed_url_prefix: str = "https://feed.phenx.de/"
+    feed_url_alternate: str = "https://phenx.de/loot"
+    feed_id_prefix: str = "https://phenx.de/loot/"
+
+
 class Config:
-    __conf = None
     __data_path = None
     __config_file = None
+    __parsed_config: None | ParsedConfig = None
 
     @staticmethod
     def config_file() -> Path:
-        if Config.__config_file is None:  # Read only once, lazy.
+        """Return the path to the config file."""
+        if Config.__config_file is None:
             data_path = Config.data_path()
             config_file = data_path / Path(CONFIG_FILE)
             Config.__config_file = config_file
@@ -23,7 +76,8 @@ class Config:
 
     @staticmethod
     def data_path() -> Path:
-        if Config.__data_path is None:  # Read only once, lazy.
+        """Return the path to the data directory."""
+        if Config.__data_path is None:
             docker_path = Path("/data")
             local_path = Path("data")
             if docker_path.exists():
@@ -34,8 +88,54 @@ class Config:
         return Config.__data_path
 
     @staticmethod
-    def config() -> configparser.ConfigParser:
-        if Config.__conf is None:  # Read only once, lazy.
-            Config.__conf = configparser.ConfigParser()
-            Config.__conf.read(Config.data_path() / CONFIG_FILE)
-        return Config.__conf
+    def get() -> ParsedConfig:
+        """Parse the config file into a ParsedConfig dataclass. Do this only once (lazy)."""
+        if Config.__parsed_config is None:
+            config = configparser.ConfigParser()
+            config.read(Config.data_path() / CONFIG_FILE)
+
+            parsed_config = ParsedConfig()
+            parsed_config.database_file = config["common"]["DatabaseFile"]
+            parsed_config.feed_file_prefix = config["common"]["FeedFilePrefix"]
+            parsed_config.log_file = config["common"]["LogFile"]
+            parsed_config.log_level = config["common"]["LogLevel"]
+            parsed_config.wait_between_runs = int(config["common"]["WaitBetweenRuns"])
+
+            parsed_config.force_update = config.getboolean("expert", "ForceUpdate")
+
+            parsed_config.offers_amazon = config.getboolean("sources_loot", "Amazon")
+            parsed_config.offers_epic = config.getboolean("sources_loot", "Epic")
+            parsed_config.offers_steam = config.getboolean("sources_loot", "Steam")
+            parsed_config.offers_gog = config.getboolean("sources_loot", "GOG")
+
+            parsed_config.info_steam = config.getboolean("sources_info", "Steam")
+            parsed_config.info_igdb = config.getboolean("sources_info", "IGDB")
+
+            parsed_config.scrape_games = config.getboolean("actions", "ScrapeGames")
+            parsed_config.scrape_loot = config.getboolean("actions", "ScrapeLoot")
+            parsed_config.scrape_info = config.getboolean("actions", "ScrapeInfo")
+            parsed_config.generate_feed = config.getboolean("actions", "GenerateFeed")
+            parsed_config.upload_feed = config.getboolean("actions", "UploadFtp")
+
+            parsed_config.telegram_access_token = config["telegram"]["AccessToken"]
+            parsed_config.telegram_developer_chat_id = int(
+                config["telegram"]["DeveloperChatID"]
+            )
+
+            parsed_config.igdb_client_id = config["igdb"]["ClientID"]
+            parsed_config.igdb_client_secret = config["igdb"]["ClientSecret"]
+
+            parsed_config.ftp_host = config["ftp"]["Host"]
+            parsed_config.ftp_username = config["ftp"]["User"]
+            parsed_config.ftp_password = config["ftp"]["Password"]
+
+            parsed_config.feed_author_name = config["feed"]["AuthorName"]
+            parsed_config.feed_author_mail = config["feed"]["AuthorMail"]
+            parsed_config.feed_author_web = config["feed"]["AuthorWeb"]
+            parsed_config.feed_url_prefix = config["feed"]["FeedUrlPrefix"]
+            parsed_config.feed_url_alternate = config["feed"]["FeedUrlAlternate"]
+            parsed_config.feed_id_prefix = config["feed"]["FeedIdPrefix"]
+
+            Config.__parsed_config = parsed_config
+
+        return Config.__parsed_config

--- a/app/database.py
+++ b/app/database.py
@@ -17,7 +17,7 @@ CURRENT_DB_VERSION = 0
 
 class LootDatabase:
     def __init__(self) -> None:
-        path = Config.data_path() / Path(Config.config()["common"]["DatabaseFile"])
+        path = Config.data_path() / Path(Config.get().database_file)
 
         self.connection = sqlite3.connect(path)
         self.cursor = self.connection.cursor()

--- a/app/scraper/info/igdb.py
+++ b/app/scraper/info/igdb.py
@@ -132,8 +132,8 @@ def get_igdb_details(search_string: str) -> Gameinfo | None:
 
 # TODO: Only use one connection, rate limit to < 4 per second
 def get_igdb_wrapper() -> IGDBWrapper | None:
-    client_id = Config.config()["igdb"]["ClientId"]
-    client_secret = Config.config()["igdb"]["ClientSecret"]
+    client_id = Config.get().igdb_client_id
+    client_secret = Config.get().igdb_client_secret
 
     r = requests.post(
         f"https://id.twitch.tv/oauth2/token?client_id={client_id}&client_secret={client_secret}&grant_type=client_credentials"

--- a/app/upload.py
+++ b/app/upload.py
@@ -6,9 +6,9 @@ from app.configparser import Config
 
 
 def upload_to_server(file: Path) -> None:
-    host = Config.config()["ftp"]["Host"]
-    user = Config.config()["ftp"]["User"]
-    password = Config.config()["ftp"]["Password"]
+    host = Config.get().ftp_host
+    user = Config.get().ftp_username
+    password = Config.get().ftp_password
 
     logging.info(f"Uploading {file.name} to host {host} as user {user}")
     with FTP_TLS(host) as session:

--- a/config.default.ini
+++ b/config.default.ini
@@ -10,18 +10,16 @@ WaitBetweenRuns = 1800
 
 [expert]
 ; Update all details for existing entries instead of only the last seen date
-ForceUpdate = yes
+ForceUpdate = no
 
 [sources_loot]
 Amazon = yes
 Epic = yes
-Gog = yes
+GOG = yes
 Steam = yes
 
 [sources_info]
-; not used yet
 Steam = yes
-; not used yet
 IGDB = yes
 
 [actions]
@@ -31,6 +29,10 @@ ScrapeLoot = yes
 ScrapeInfo = yes
 GenerateFeed = yes
 UploadFtp = no
+
+[telegram]
+AccessToken = TOKEN_HERE
+DeveloperChatId = ID_HERE
 
 [igdb]
 ; Twitch App API Key


### PR DESCRIPTION
Makes it type safe and also only one central spot for all the parsing. We can fail early if the config is wrong.

Signed-off-by: Eiko Wagenknecht <git@eiko-wagenknecht.de>