### PR TITLE
Add support for announcements

### DIFF
--- a/alembic/versions/20220422_090529_last_sent_offer.py
+++ b/alembic/versions/20220422_090529_last_sent_offer.py
@@ -5,9 +5,9 @@ Revises: 8cfaaf08b306
 Create Date: 2022-04-22 09:05:29.092417+00:00
 
 """
-from alembic import op
 import sqlalchemy as sa
 
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "52ea632ee417"

--- a/alembic/versions/20220423_175707_announcements.py
+++ b/alembic/versions/20220423_175707_announcements.py
@@ -5,11 +5,10 @@ Revises: 52ea632ee417
 Create Date: 2022-04-23 17:57:07.548114+00:00
 
 """
-from alembic import op
 import sqlalchemy as sa
 
+from alembic import op
 from app.sqlalchemy import AwareDateTime
-
 
 # revision identifiers, used by Alembic.
 revision = "fc43de437432"
@@ -33,7 +32,12 @@ def upgrade() -> None:
     )
     with op.batch_alter_table("users", schema=None) as batch_op:  # type: ignore
         batch_op.add_column(
-            sa.Column("last_announcement_id", sa.Integer(), nullable=False)
+            sa.Column("last_announcement_id", sa.Integer(), nullable=True)
+        )
+    op.execute("UPDATE users SET last_announcement_id = 0")
+    with op.batch_alter_table("users", schema=None) as batch_op:  # type: ignore
+        batch_op.alter_column(
+            "last_announcement_id", existing_type=sa.Integer(), nullable=False
         )
 
 

--- a/alembic/versions/20220423_175707_announcements.py
+++ b/alembic/versions/20220423_175707_announcements.py
@@ -1,0 +1,44 @@
+"""Announcements
+
+Revision ID: fc43de437432
+Revises: 52ea632ee417
+Create Date: 2022-04-23 17:57:07.548114+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+from app.sqlalchemy import AwareDateTime
+
+
+# revision identifiers, used by Alembic.
+revision = "fc43de437432"
+down_revision = "52ea632ee417"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "announcements",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column(
+            "channel",
+            sa.Enum("ALL", "FEED", "TELEGRAM", name="channel"),
+            nullable=False,
+        ),
+        sa.Column("date", AwareDateTime(), nullable=False),
+        sa.Column("text_markdown", sa.String(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    with op.batch_alter_table("users", schema=None) as batch_op:  # type: ignore
+        batch_op.add_column(
+            sa.Column("last_announcement_id", sa.Integer(), nullable=False)
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("users", schema=None) as batch_op:  # type: ignore
+        batch_op.drop_column("last_announcement_id")
+
+    op.drop_table("announcements")

--- a/app/common.py
+++ b/app/common.py
@@ -6,7 +6,7 @@ TIMESTAMP_READABLE_WITH_HOUR = "%Y-%m-%d - %H:%M UTC"
 
 
 class OfferType(Enum):
-    LOOT = "Loot"
+    LOOT = "Loot"  # DLC, Ingame cash, etc.
     GAME = "Game"
 
 
@@ -17,5 +17,13 @@ class Source(Enum):
     GOG = "GOG"
 
 
+class Channel(Enum):
+    ALL = "All"
+    FEED = "Feed"
+    TELEGRAM = "Telegram"
+
+
 def chunkstring(string: str, length: int) -> list[str]:
-    return list((string[0 + i : length + i] for i in range(0, len(string), length)))
+    """Split a string into chunks of the given length (last chunk may be shorter)."""
+    chunk_iterator = (string[0 + i : length + i] for i in range(0, len(string), length))
+    return list(chunk_iterator)

--- a/app/sqlalchemy.py
+++ b/app/sqlalchemy.py
@@ -25,7 +25,7 @@ from sqlalchemy.orm import registry, relationship, scoped_session, sessionmaker
 
 from alembic import command
 from alembic.config import Config as AlembicConfig
-from app.common import OfferType, Source
+from app.common import Channel, OfferType, Source
 from app.configparser import Config
 
 mapper_registry = registry()
@@ -47,7 +47,19 @@ class AwareDateTime(TypeDecorator):
             return None
 
 
+class Announcement(Base):
+    __tablename__ = "announcements"
+
+    id: int = Column(Integer, primary_key=True, nullable=False)
+
+    channel: Channel = Column(Enum(Channel), nullable=False)
+    date: datetime = Column(AwareDateTime, nullable=False)
+    text_markdown: str = Column(String, nullable=False)
+
+
 class Game(Base):
+    """A game (e.g. "The Witcher 3")."""
+
     __tablename__ = "games"
 
     id: int = Column(Integer, primary_key=True, nullable=False)
@@ -70,6 +82,8 @@ class Game(Base):
 
 
 class IgdbInfo(Base):
+    """Information about a Game, gathered from IDGB."""
+
     __tablename__ = "igdb_info"
 
     id: int = Column(Integer, primary_key=True, nullable=False)
@@ -102,6 +116,8 @@ class IgdbInfo(Base):
 
 
 class SteamInfo(Base):
+    """Information about a Game, gathered from Steam."""
+
     __tablename__ = "steam_info"
 
     id: int = Column(Integer, primary_key=True, nullable=False)
@@ -145,6 +161,8 @@ class SteamInfo(Base):
 
 
 class Offer(Base):
+    """An offer, can be for a game or soem other game related content (loot)."""
+
     __tablename__ = "offers"
 
     id: int = Column(Integer, primary_key=True, nullable=False)
@@ -184,6 +202,8 @@ class Offer(Base):
 
 
 class User(Base):
+    """A user of the website."""
+
     __tablename__ = "users"
 
     id: int = Column(Integer, primary_key=True, nullable=False)
@@ -199,8 +219,12 @@ class User(Base):
         "TelegramSubscription", back_populates="user", cascade="all, delete-orphan"
     )
 
+    last_announcement_id: int = Column(Integer, nullable=False, default=0)
+
 
 class TelegramSubscription(Base):
+    """Subscription of a user to a category for Telegram notifications."""
+
     __tablename__ = "telegram_subscriptions"
 
     id: int = Column(Integer, primary_key=True, nullable=False)

--- a/app/tools.py
+++ b/app/tools.py
@@ -1,0 +1,63 @@
+import logging
+from datetime import datetime, timezone
+
+from selenium.webdriver.chrome.webdriver import WebDriver
+from sqlalchemy.orm import Session
+
+from app.common import Channel
+from app.scraper.info.steam import get_steam_details
+from app.sqlalchemy import Announcement, SteamInfo
+from app.telegram import markdown_escape
+
+
+def refresh_all_steam_info(session: Session, webdriver: WebDriver) -> None:
+    """
+    Refresh Steam information for all games in the database
+    """
+    logging.info("Refreshing Steam information")
+    steam_info: SteamInfo
+    for steam_info in session.query(SteamInfo):
+        new_steam_info = get_steam_details(id=steam_info.id, driver=webdriver)
+        if new_steam_info is None:
+            return
+        steam_info.name = new_steam_info.name
+        steam_info.short_description = new_steam_info.short_description
+        steam_info.release_date = new_steam_info.release_date
+        steam_info.publishers = new_steam_info.publishers
+        steam_info.image_url = new_steam_info.image_url
+        steam_info.recommendations = new_steam_info.recommendations
+        steam_info.percent = new_steam_info.percent
+        steam_info.score = new_steam_info.score
+        steam_info.metacritic_score = new_steam_info.metacritic_score
+        steam_info.metacritic_url = new_steam_info.metacritic_url
+        steam_info.recommended_price_eur = new_steam_info.recommended_price_eur
+
+
+def add_announcement(session: Session) -> None:
+    """
+    Add an announcement to the database
+    """
+
+    announcement_header = "2022-04-23 - Announcing: Announcements!"
+    announcement_text = (
+        "Yes, that's right. This is an announcement to announce announcements! "
+        "From now on, every time there is something new to announce, you will get a message from me. "
+        "I'll try to keep the spam volume low, though ;-)"
+        "That's it for now! I hope you enjoyed the announcement!"
+    )
+
+    announcement_full = (
+        "*"
+        + markdown_escape(announcement_header)
+        + "*"
+        + "\n\n"
+        + markdown_escape(announcement_text)
+    )
+
+    announcement = Announcement(
+        channel=Channel.TELEGRAM,
+        date=datetime.now().replace(tzinfo=timezone.utc),
+        text_markdown=announcement_full,
+    )
+    session.add(announcement)
+    session.commit()

--- a/lootscraper.py
+++ b/lootscraper.py
@@ -22,7 +22,7 @@ from app.scraper.loot.amazon_prime import AmazonScraper
 from app.scraper.loot.epic_games import EpicScraper
 from app.scraper.loot.gog import GogScraper
 from app.scraper.loot.steam import SteamScraper
-from app.sqlalchemy import Game, LootDatabase, Offer, SteamInfo, User
+from app.sqlalchemy import Game, LootDatabase, Offer, User
 from app.telegram import TelegramBot
 from app.upload import upload_to_server
 
@@ -114,7 +114,6 @@ def quit(signo: int, _frame: FrameType | None) -> None:
 def job(db: LootDatabase) -> None:
     webdriver: WebDriver
     with get_pagedriver() as webdriver:
-        # refresh_all_steam_info(db.session, webdriver) # DEBUG ONLY
         scraped_offers: dict[str, dict[str, list[Offer]]] = {}
 
         cfg_what_to_scrape = {
@@ -284,29 +283,6 @@ def job(db: LootDatabase) -> None:
         logging.info("Skipping feed generation, disabled")
 
     db.session.commit()
-
-
-def refresh_all_steam_info(session: Session, webdriver: WebDriver) -> None:
-    """
-    Refresh Steam information for all games in the database
-    """
-    logging.info("Refreshing Steam information")
-    steam_info: SteamInfo
-    for steam_info in session.query(SteamInfo):
-        new_steam_info = get_steam_details(id=steam_info.id, driver=webdriver)
-        if new_steam_info is None:
-            return
-        steam_info.name = new_steam_info.name
-        steam_info.short_description = new_steam_info.short_description
-        steam_info.release_date = new_steam_info.release_date
-        steam_info.publishers = new_steam_info.publishers
-        steam_info.image_url = new_steam_info.image_url
-        steam_info.recommendations = new_steam_info.recommendations
-        steam_info.percent = new_steam_info.percent
-        steam_info.score = new_steam_info.score
-        steam_info.metacritic_score = new_steam_info.metacritic_score
-        steam_info.metacritic_url = new_steam_info.metacritic_url
-        steam_info.recommended_price_eur = new_steam_info.recommended_price_eur
 
 
 def add_game_info(offer: Offer, session: Session, webdriver: WebDriver) -> None:

--- a/lootscraper.py
+++ b/lootscraper.py
@@ -81,6 +81,7 @@ def main() -> None:
                 if Config.get().telegram_bot:
                     session: Session = db.session
                     for user in session.execute(select(User)).scalars().all():
+                        bot.send_new_announcements(user)
                         bot.send_new_offers(user)
             except OperationalError as oe:
                 logging.error(f"Database error: {oe}")

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -37,7 +37,7 @@ class VariousTests(unittest.TestCase):
                 sleep(10000)
             # Assert
 
-    def test_telegram_messagesend(self) -> None:
+    def test_telegram_messagesend_registered_user(self) -> None:
         with (
             LootDatabase(echo=True) as db,
             TelegramBot(Config.get(), db.session) as bot,
@@ -48,13 +48,40 @@ class VariousTests(unittest.TestCase):
             # Act
             offer: Offer = session.execute(select(Offer)).scalars().first()
             user: User = (
-                session.execute(select(User).where(User.telegram_id == 724039662))
+                session.execute(
+                    select(User).where(User.telegram_id == 724039662)
+                )  # Eiko
                 .scalars()
                 .first()
             )
-            bot.send_offer(offer, user)
+
+            message = bot.send_offer(offer, user)
 
             # Assert
+            self.assertTrue(message)
+
+    def test_telegram_messagesend_unregistered_user(self) -> None:
+        with (
+            LootDatabase(echo=True) as db,
+            TelegramBot(Config.get(), db.session) as bot,
+        ):
+            # Arrange
+            session: Session = db.session
+
+            # Act
+            offer: Offer = session.execute(select(Offer)).scalars().first()
+            user: User = (
+                session.execute(
+                    select(User).where(User.telegram_id == 99921143)
+                )  # Martin
+                .scalars()
+                .first()
+            )
+
+            message = bot.send_offer(offer, user)
+
+            # Assert
+            self.assertFalse(message)
 
     def test_telegram_new_offers(self) -> None:
         with (


### PR DESCRIPTION
Can store announcements in Markdown format now to send to Telegram users. This can (and will) be used e.g. if a new source is added.