### PR TITLE
Scroll to bottom for Epic images

### DIFF
--- a/app/scraper/loot/epic_games.py
+++ b/app/scraper/loot/epic_games.py
@@ -65,6 +65,8 @@ class EpicGamesScraper(Scraper):
                     (By.XPATH, """//h2[text()="Free Games"]""")
                 )
             )
+
+            Scraper.scroll_page_to_bottom(driver)
         except WebDriverException:
             filename = (
                 Config.data_path()


### PR DESCRIPTION
Epic first loads a placeholder in the src atribute and only after scrolling down far enough the actual img url is inserted. So we scroll down first.

Signed-off-by: Eiko Wagenknecht <git@eiko-wagenknecht.de>