### PR TITLE
Catch Amazon offers that are valid too long

### DIFF
--- a/src/lootscraper/scraper/loot/amazon_base.py
+++ b/src/lootscraper/scraper/loot/amazon_base.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from datetime import datetime
 
 from playwright.async_api import Error, Locator
 
@@ -31,6 +32,11 @@ class AmazonBaseScraper(Scraper):  # pylint: disable=W0223
 
     def get_page_ready_selector(self) -> str:
         return ".offer-list__content"
+
+    @staticmethod
+    def is_fake_always(valid_to: datetime | None) -> bool:
+        """Offers on Amazon are never valid forever."""
+        return False
 
     async def read_base_raw_offer(self, element: Locator) -> AmazonRawOffer:
         title = await element.locator(

--- a/src/lootscraper/scraper/loot/scraper.py
+++ b/src/lootscraper/scraper/loot/scraper.py
@@ -167,13 +167,13 @@ class Scraper:
         Categorize offers by title (demo, etc.)
         """
         for offer in offers:
-            if Scraper.is_demo(offer.title):
+            if self.is_demo(offer.title):
                 offer.category = Category.DEMO
                 continue
-            if Scraper.is_prerelease(offer.title):
+            if self.is_prerelease(offer.title):
                 offer.category = Category.PRERELEASE
                 continue
-            if Scraper.is_fake_always(offer.valid_to):
+            if self.is_fake_always(offer.valid_to):
                 offer.duration = OfferDuration.ALWAYS
                 continue
 


### PR DESCRIPTION
Some amazon offers currently show "valid for 330 days" and are thus categorized as "ALWAYS" valid. That is wrong because Amazon offers always expire and sometimes just set the dates wrong. So now this categorization is definable per scraper.