### PR TITLE
feat: use a custom scheduler for each scraper

### DIFF
--- a/config.default.toml
+++ b/config.default.toml
@@ -5,8 +5,6 @@ feed_file_prefix = "lootscraper"
 log_file = "lootscraper.log"
 # One of: DEBUG, INFO, WARNING, ERROR, CRITICAL
 log_level = "INFO"
-# How long the script waits between runs (in seconds). 0 for single run.
-wait_between_runs_seconds = 0
 
 [expert]
 # Output all database queries to the console

--- a/poetry.lock
+++ b/poetry.lock
@@ -733,6 +733,17 @@ socks = ["httpx[socks]"]
 webhooks = ["tornado (>=6.3.3,<6.4.0)"]
 
 [[package]]
+name = "pytz"
+version = "2023.3.post1"
+description = "World timezone definitions, modern and historical"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pytz-2023.3.post1-py2.py3-none-any.whl", hash = "sha256:ce42d816b81b68506614c11e8937d3aa9e41007ceb50bfdcb0749b921bf646c7"},
+    {file = "pytz-2023.3.post1.tar.gz", hash = "sha256:7b4fddbeb94a1eba4b557da24f19fdf9db575192544270a9101d8509f9f43d7b"},
+]
+
+[[package]]
 name = "rich"
 version = "13.6.0"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
@@ -808,6 +819,17 @@ psutil = ">=5.9.2"
 pynvml = ">=11.0.0,<11.5"
 rich = ">=10.7.0"
 wheel = ">=0.36.1"
+
+[[package]]
+name = "schedule"
+version = "1.2.1"
+description = "Job scheduling for humans."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "schedule-1.2.1-py2.py3-none-any.whl", hash = "sha256:14cdeb083a596aa1de6dc77639a1b2ac8bf6eaafa82b1c9279d3612823063d01"},
+    {file = "schedule-1.2.1.tar.gz", hash = "sha256:843bc0538b99c93f02b8b50e3e39886c06f2d003b24f48e1aa4cadfa3f341279"},
+]
 
 [[package]]
 name = "setuptools"
@@ -982,4 +1004,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11.1"
-content-hash = "5a586b085348b207c38a6e4b7a3cf879890622d45834e91e5d3a4043d3c76008"
+content-hash = "fb1ca4485ef1c626d3b673f12423d1d7dcc2cff4c89dfe2e7550b3d908e8837c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ SQLAlchemy = "^2.0.22"
 Unidecode = "^1.3.7"
 xvfbwrapper = "^0.2.9"
 jinja2 = "^3.1.2"
+schedule = "^1.2.1"
+pytz = "^2023.3.post1"
 
 [tool.poetry.group.dev]
 optional = true
@@ -120,6 +122,7 @@ select = [
 
 ignore = [
     "ANN101", # Missing type annotation for self in method - Not needed with Self type
+    "ANN102", # Missing type annotation for cls in classmethod - Not needed
     "S101",   # Use of assert detected
     "TRY003", # Long messages in exceptions
     "D100",   # Missing docstring in public module

--- a/src/lootscraper/config.py
+++ b/src/lootscraper/config.py
@@ -28,7 +28,6 @@ class ParsedConfig:
     feed_file_prefix: str = "lootscraper"
     log_file: str = "lootscraper.log"
     log_level: str = "INFO"
-    wait_between_runs_seconds: int = 0
 
     # Expert
     db_echo: bool = False
@@ -125,11 +124,6 @@ class Config:
 
             with contextlib.suppress(KeyError):
                 parsed_config.log_level = data["common"]["log_level"]
-
-            with contextlib.suppress(KeyError):
-                parsed_config.wait_between_runs_seconds = data["common"][
-                    "wait_between_runs_seconds"
-                ]
 
             # Expert
             with contextlib.suppress(KeyError):

--- a/src/lootscraper/database.py
+++ b/src/lootscraper/database.py
@@ -295,6 +295,7 @@ class LootDatabase:
     def read_active_offers(self, time: datetime) -> Sequence[Offer]:
         session: Session = self.Session()
         try:
+            # TODO: Add option for custom prefiltering because this is a lot!
             # Prefilter to reduce database load. The details are handled below.
             offers = (
                 session.execute(

--- a/src/lootscraper/main.py
+++ b/src/lootscraper/main.py
@@ -3,20 +3,32 @@ import asyncio
 import logging
 import shutil
 import sys
-from contextlib import ExitStack, suppress
-from datetime import datetime, timedelta, timezone
+from contextlib import AsyncExitStack, suppress
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
+from typing import TYPE_CHECKING, Type
 
+import schedule
 from sqlalchemy.exc import OperationalError
 
 from lootscraper import __version__
+from lootscraper.browser import get_browser_context
 from lootscraper.common import TIMESTAMP_LONG
 from lootscraper.config import Config
 from lootscraper.database import LootDatabase
-from lootscraper.processing import scrape_new_offers, send_new_offers_telegram
+from lootscraper.processing import (
+    action_generate_feed,
+    process_new_offers,
+    send_new_offers_telegram,
+)
+from lootscraper.scraper import get_all_scrapers
 from lootscraper.telegrambot import TelegramBot, TelegramLoggingHandler
 from lootscraper.tools import cleanup
+
+if TYPE_CHECKING:
+    from playwright.async_api import BrowserContext
+
+    from lootscraper.scraper.scraper_base import Scraper
 
 try:
     from xvfbwrapper import Xvfb
@@ -184,48 +196,90 @@ async def run_scraper_loop(
     db: LootDatabase,
     telegram_queue: asyncio.Queue[int],
 ) -> None:
-    """
-    Run the scraping job in a loop with a waiting time of x seconds (set in the
-    config file) between the runs.
-    """
-    with ExitStack() as stack:
+    """Run the scraping job in a loop with the scheduling set in the scraper classes."""
+    # No scrapers, no point in continuing
+    if len(Config.get().enabled_offer_sources) == 0:
+        logger.warning("No sources enabled, exiting.")
+        return
+
+    async with AsyncExitStack() as stack:
         # Check the "global" variable (set on import) to see if we can use a
         # virtual display
         if use_virtual_display:
             stack.enter_context(Xvfb())
 
-        time_between_runs = int(Config.get().wait_between_runs_seconds)
+        # Use one single browser instance for all scrapers
+        browser_context: BrowserContext = await stack.enter_async_context(
+            get_browser_context(),
+        )
 
-        # Loop forever (until terminated by external events)
-        run_no = 0
+        # Use a single database session for all scrapers
+        db_session = db.Session()
+
+        # Initialize the task queue. The queue is used to schedule the scraping
+        # tasks. Each scraper is scheduled by adding a task to the queue. The
+        # worker function then dequeues the task and calls the appropriate
+        # scraper.
+        task_queue: asyncio.Queue[Type[Scraper]] = asyncio.Queue()
+
+        async def worker() -> None:
+            run_no = 0
+            while True:
+                # This triggers when the time has come to run a scraper
+                scraper_class = await task_queue.get()
+
+                run_no += 1
+                logger.debug(f"Executing scheduled task #{run_no}.")
+
+                try:
+                    scraper_instance = scraper_class(context=browser_context)
+                    scraped_offers = await scraper_instance.scrape()
+                    await process_new_offers(
+                        db,
+                        browser_context,
+                        db_session,
+                        scraped_offers,
+                    )
+
+                    if Config.get().generate_feed:
+                        await action_generate_feed(db)
+                    else:
+                        logging.info("Skipping feed generation because it is disabled.")
+
+                    if Config.get().telegram_bot:
+                        await telegram_queue.put(run_no)
+                    else:
+                        logging.debug(
+                            "Skipping Telegram notification because it is disabled.",
+                        )
+                except OperationalError:
+                    # We handle DB errors on a higher level
+                    raise
+                except Exception as e:
+                    # This is our catch-all. Something really unexpected occurred.
+                    # Log it with the highest priority and continue with the
+                    # next scheduled run when it's due.
+                    logger.critical(e)
+
+                task_queue.task_done()
+
+        # Schedule each scraper that is enabled
+        for scraper_class in get_all_scrapers():
+            for job in scraper_class.get_schedule():
+                if scraper_class.is_enabled():
+                    # Enqueue the scraper job into the task queue with the
+                    # scraper class and the database session as arguments
+                    job.do(task_queue.put_nowait, scraper_class)
+
+        # Create the worker task that will run the next task in the queue when
+        # it is due
+        asyncio.create_task(worker())
+
+        # Run tasks once after startup
+        schedule.run_all()
+
+        # Then run the tasks in a loop according to their schedule
         while True:
-            run_no += 1
-
-            logger.info(f"Starting scraping run #{run_no}.")
-
-            try:
-                await scrape_new_offers(db)
-            except OperationalError:
-                # We handle DB errors on a higher level
-                raise
-            except Exception as e:
-                # This is our catch-all. Something really unexpected occurred.
-                # Log it with the highest priority and continue with the
-                # next run.
-                logger.critical(e)
-
-            if time_between_runs == 0:
-                break
-
-            next_execution = datetime.now(tz=timezone.utc) + timedelta(
-                seconds=time_between_runs,
-            )
-
-            logger.info(f"Next scraping run will be at {next_execution.isoformat()}.")
-
-            if Config.get().telegram_bot:
-                await telegram_queue.put(run_no)
-
-            await asyncio.sleep(time_between_runs)
-
-        logger.info(f"Finished {run_no} runs")
+            logger.debug("Checking if there are tasks to schedule.")
+            schedule.run_pending()
+            await asyncio.sleep(1)

--- a/src/lootscraper/scraper/amazon_base.py
+++ b/src/lootscraper/scraper/amazon_base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+import schedule
 from playwright.async_api import Error, Locator
 
 from lootscraper.common import OfferDuration, Source
@@ -28,6 +29,10 @@ class AmazonBaseScraper(Scraper):
     @staticmethod
     def get_duration() -> OfferDuration:
         return OfferDuration.CLAIMABLE
+
+    @staticmethod
+    def get_schedule() -> list[schedule.Job]:
+        return [schedule.every(30).minutes]
 
     def offers_expected(self) -> bool:
         return True

--- a/src/lootscraper/scraper/apple_games.py
+++ b/src/lootscraper/scraper/apple_games.py
@@ -5,6 +5,8 @@ import urllib.parse
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
+import schedule
+
 from lootscraper.common import OfferDuration, OfferType, Source
 from lootscraper.database import Offer
 from lootscraper.scraper.scraper_base import OfferHandler, RawOffer, Scraper
@@ -31,6 +33,11 @@ class AppleGamesScraper(Scraper):
     @staticmethod
     def get_type() -> OfferType:
         return OfferType.GAME
+
+    @staticmethod
+    def get_schedule() -> list[schedule.Job]:
+        # Run once per day only to avoid getting blocked
+        return [schedule.every().day.at("12:00")]
 
     @staticmethod
     def get_duration() -> OfferDuration:

--- a/src/lootscraper/scraper/epic_games.py
+++ b/src/lootscraper/scraper/epic_games.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
+import schedule
+
 from lootscraper.common import OfferDuration, OfferType, Source
 from lootscraper.database import Offer
 from lootscraper.scraper.scraper_base import OfferHandler, RawOffer, Scraper
@@ -31,6 +33,15 @@ class EpicGamesScraper(Scraper):
     @staticmethod
     def get_type() -> OfferType:
         return OfferType.GAME
+
+    @staticmethod
+    def get_schedule() -> list[schedule.Job]:
+        # Run every thursday at 11:05 US eastern time (new offers are usually
+        # available then) and as a backup every day at 13:00 US eastern time.
+        return [
+            schedule.every().thursday.at("11:05", "US/Eastern"),
+            schedule.every().day.at("13:00", "US/Eastern"),
+        ]
 
     @staticmethod
     def get_duration() -> OfferDuration:

--- a/src/lootscraper/scraper/gog_base.py
+++ b/src/lootscraper/scraper/gog_base.py
@@ -1,5 +1,6 @@
 import asyncio
 
+import schedule
 from playwright.async_api import Page
 
 from lootscraper.common import OfferType, Source
@@ -14,6 +15,10 @@ class GogBaseScraper(Scraper):
     @staticmethod
     def get_type() -> OfferType:
         return OfferType.GAME
+
+    @staticmethod
+    def get_schedule() -> list[schedule.Job]:
+        return [schedule.every(30).minutes]
 
     @staticmethod
     def sanitize_img_url(img_url: str | None) -> str | None:

--- a/src/lootscraper/scraper/google_games.py
+++ b/src/lootscraper/scraper/google_games.py
@@ -4,6 +4,8 @@ import logging
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
+import schedule
+
 from lootscraper.common import OfferDuration, OfferType, Source
 from lootscraper.database import Offer
 from lootscraper.scraper.scraper_base import OfferHandler, RawOffer, Scraper
@@ -25,6 +27,11 @@ class GoogleGamesScraper(Scraper):
     @staticmethod
     def get_type() -> OfferType:
         return OfferType.GAME
+
+    @staticmethod
+    def get_schedule() -> list[schedule.Job]:
+        # Run once per day only to avoid getting blocked
+        return [schedule.every().day.at("12:00")]
 
     @staticmethod
     def get_duration() -> OfferDuration:

--- a/src/lootscraper/scraper/humble_games.py
+++ b/src/lootscraper/scraper/humble_games.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
+import schedule
+
 from lootscraper.browser import get_new_page
 from lootscraper.common import Category, OfferDuration, OfferType, Source
 from lootscraper.database import Offer
@@ -38,6 +40,10 @@ class HumbleGamesScraper(Scraper):
     @staticmethod
     def get_type() -> OfferType:
         return OfferType.GAME
+
+    @staticmethod
+    def get_schedule() -> list[schedule.Job]:
+        return [schedule.every(3).hours]
 
     @staticmethod
     def get_duration() -> OfferDuration:

--- a/src/lootscraper/scraper/itch_games.py
+++ b/src/lootscraper/scraper/itch_games.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from datetime import datetime, timezone
 
+import schedule
 from playwright.async_api import Locator, Page
 from playwright.async_api import TimeoutError as PlaywrightTimeoutError
 
@@ -24,6 +25,10 @@ class ItchGamesScraper(Scraper):
     @staticmethod
     def get_type() -> OfferType:
         return OfferType.GAME
+
+    @staticmethod
+    def get_schedule() -> list[schedule.Job]:
+        return [schedule.every(6).hours]
 
     @staticmethod
     def get_duration() -> OfferDuration:

--- a/src/lootscraper/scraper/scraper_base.py
+++ b/src/lootscraper/scraper/scraper_base.py
@@ -22,6 +22,8 @@ from lootscraper.utils import (
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
+    import schedule
+
     from lootscraper.database import Offer
 
 logger = logging.getLogger(__name__)
@@ -67,9 +69,24 @@ class Scraper:
             logger.info("No offers found.")
         return filtered_offers
 
+    @classmethod
+    def is_enabled(cls) -> bool:
+        cfg = Config.get()
+
+        return (
+            cls.get_type() in cfg.enabled_offer_types
+            and cls.get_duration() in cfg.enabled_offer_durations
+            and cls.get_source() in cfg.enabled_offer_sources
+        )
+
     @staticmethod
     def get_type() -> OfferType:
         """Return the type of the offers this scraper is looking for."""
+        raise NotImplementedError("Please implement this method")
+
+    @staticmethod
+    def get_schedule() -> list[schedule.Job]:
+        """Return when the scraper should run."""
         raise NotImplementedError("Please implement this method")
 
     @staticmethod

--- a/src/lootscraper/scraper/steam_base.py
+++ b/src/lootscraper/scraper/steam_base.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
+import schedule
+
 from lootscraper.browser import get_new_page
 from lootscraper.common import OfferDuration, OfferType, Source
 from lootscraper.database import Offer
@@ -37,6 +39,10 @@ class SteamBaseScraper(Scraper):
     @staticmethod
     def get_duration() -> OfferDuration:
         return OfferDuration.CLAIMABLE
+
+    @staticmethod
+    def get_schedule() -> list[schedule.Job]:
+        return [schedule.every(30).minutes]
 
     def get_steam_category(self) -> int:
         raise NotImplementedError("Please implement this method")

--- a/src/lootscraper/scraper/ubisoft_games.py
+++ b/src/lootscraper/scraper/ubisoft_games.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
+import schedule
+
 from lootscraper.common import OfferDuration, OfferType, Source
 from lootscraper.database import Offer
 from lootscraper.scraper.scraper_base import OfferHandler, RawOffer, Scraper
@@ -31,6 +33,10 @@ class UbisoftGamesScraper(Scraper):
     @staticmethod
     def get_type() -> OfferType:
         return OfferType.GAME
+
+    @staticmethod
+    def get_schedule() -> list[schedule.Job]:
+        return [schedule.every(3).hours]
 
     @staticmethod
     def get_duration() -> OfferDuration:


### PR DESCRIPTION
Since the scrapers have different time schedules where they should run, they now set different schedules.
E.g. Epic every thursday 11 EST, Amazon every 30min, Apple and Google once per day (to not be blocked) etc.