### PR TITLE
feat: run epic scraper every day

### DIFF
--- a/src/lootscraper/scraper/epic_games.py
+++ b/src/lootscraper/scraper/epic_games.py
@@ -36,10 +36,10 @@ class EpicGamesScraper(Scraper):
 
     @staticmethod
     def get_schedule() -> list[schedule.Job]:
-        # Run every thursday at 11:05 US eastern time (new offers are usually
+        # Run every day at 11:05 US eastern time (new offers are usually
         # available then) and as a backup every day at 13:00 US eastern time.
         return [
-            schedule.every().thursday.at("11:05", "US/Eastern"),
+            schedule.every().day.at("11:05", "US/Eastern"),
             schedule.every().day.at("13:00", "US/Eastern"),
         ]
 


### PR DESCRIPTION
Since epic offers now are available daily again, the schedule is changed accordingly. I expect this to have no negative consequences and will leave it at daily if there are indeed no problems with the frequency.