### PR TITLE
feat: update previously scraped offers

### DIFF
--- a/src/lootscraper/processing.py
+++ b/src/lootscraper/processing.py
@@ -72,7 +72,7 @@ async def process_new_offers(
                 nr_of_new_offers += 1
             else:
                 # Update offers that already have been scraped.
-                db.touch_db_offer(existing_entry)
+                db.update_db_offer(existing_entry, scraped_offer)
 
         if new_offer_titles:
             logging.info(


### PR DESCRIPTION
Sometimes in some scraping runs the valid to date is missing. These offers have been seen as separate offers when they were really the same. This should fix the behaviour.