### PR TITLE
fix: downgrade game info fetch failures from error to warn level

### DIFF
--- a/src/services/gameinfo.ts
+++ b/src/services/gameinfo.ts
@@ -152,7 +152,7 @@ class GameInfoService {
 
       return details;
     } catch (error) {
-      logger.error(
+      logger.warn(
         `Steam info fetch failed: ${error instanceof Error ? error.message : String(error)}`,
       );
       return null;
@@ -178,7 +178,7 @@ class GameInfoService {
 
       return await this.igdbClient.getDetails(gameId);
     } catch (error) {
-      logger.error(
+      logger.warn(
         `IGDB info fetch failed: ${error instanceof Error ? error.message : String(error)}`,
       );
       return null;

--- a/src/services/gameinfo/steam/steam.ts
+++ b/src/services/gameinfo/steam/steam.ts
@@ -84,11 +84,9 @@ export class SteamClient {
       return bestMatch?.appId ?? null;
     } catch (error) {
       if (error instanceof errors.TimeoutError) {
-        logger.error("Steam search timed out");
+        logger.warn("Steam search timed out");
       }
-      logger.error(
-        `Steam search failed: ${error instanceof Error ? error.message : String(error)}`,
-      );
+      logger.warn(`Steam search failed: ${error instanceof Error ? error.message : String(error)}`);
       return null;
     } finally {
       await page.close();
@@ -190,9 +188,9 @@ export class SteamClient {
       return data;
     } catch (error) {
       if (error instanceof errors.TimeoutError) {
-        logger.error("Steam page load timed out");
+        logger.warn("Steam page load timed out");
       }
-      logger.error(
+      logger.warn(
         `Steam page scraping failed: ${error instanceof Error ? error.message : String(error)}`,
       );
       return {};


### PR DESCRIPTION
Game info enrichment failures (Steam page scraping, Steam search, IGDB
fetch) were logging at error level, which sent Telegram alerts on every
transient failure. These are gracefully handled (returning null/empty)
and don't affect core functionality. Downgrading to warn prevents noisy
Telegram notifications while still logging for debugging.

https://claude.ai/code/session_019iKXS5UsMsqsQFZZxbPGGL